### PR TITLE
Removed G+ Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,4 @@ You can find more info on us here:
 * https://www.facebook.com/causecode/
 * https://twitter.com/causecode
 * https://www.instagram.com/causecode/
-* https://plus.google.com/u/1/b/100959550068865457513/+CausecodeTechnologiesPune/posts
 * https://www.youtube.com/watch?v=rIa6u2soUkw


### PR DESCRIPTION
As Google plus is no longer working for normal users and listed page was not the part of Gsuit account. I have removed the link from Readme.md as it was giving 404 😀